### PR TITLE
Make compatible with pull_request_target

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The ideal workflow configuration is:
 ```yaml
 name: "Reviewer lottery"
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, ready_for_review, reopened]
 
 jobs:
@@ -73,3 +73,8 @@ This way, you can add and remove yourself from the lottery easily in case you go
 are not working on this repo for some time, etc.
 
 Reviewing code is good and fun, but we want to be able to disconnect from time to time! :palm_tree: :sunny:
+
+**Why on pull_request_target?**
+
+By running this action on `pull_request_target` we enable this aciton to be performed on PRs opened by users with 
+readonly access to the repo, for example those by Dependabot.

--- a/__tests__/lottery.test.ts
+++ b/__tests__/lottery.test.ts
@@ -4,12 +4,12 @@ import {runLottery, Pull} from '../src/lottery'
 
 const octokit = new Octokit()
 const prNumber = 123
-const ref = `refs/pull/${prNumber}`
-const basePull = {number: prNumber, head: {ref: ref}}
+const ref = 'refs/pull/branch-name'
+const basePull = {number: prNumber, head: {ref}}
 
 const mockGetPull = (pull: Pull) =>
   nock('https://api.github.com')
-    .get(`/repos/uesteibar/repository/pulls`)
+    .get('/repos/uesteibar/repository/pulls')
     .reply(200, [pull])
 
 test('selects reviewers from a pool of users, ignoring author', async () => {
@@ -48,7 +48,7 @@ test('selects reviewers from a pool of users, ignoring author', async () => {
 
   await runLottery(octokit, config, {
     repository: 'uesteibar/repository',
-    ref: `refs/pull/${prNumber}`
+    ref
   })
 
   getPullMock.done()
@@ -78,7 +78,7 @@ test("doesn't assign reviewers if the PR is in draft state", async () => {
 
   await runLottery(octokit, config, {
     repository: 'uesteibar/repository',
-    ref: `refs/pull/${prNumber}`
+    ref
   })
 
   getPullMock.done()
@@ -122,7 +122,7 @@ test("doesn't send invalid reviewers if there is no elegible reviewers from one 
 
   await runLottery(octokit, config, {
     repository: 'uesteibar/repository',
-    ref: `refs/pull/${prNumber}`
+    ref
   })
 
   postReviewersMock.done()
@@ -169,7 +169,7 @@ test('selects internal reviewers if configured and author belongs to group', asy
 
   await runLottery(octokit, config, {
     repository: 'uesteibar/repository',
-    ref: `refs/pull/${prNumber}`
+    ref
   })
 
   getPullMock.done()
@@ -217,7 +217,7 @@ test("doesn't assign internal reviewers if the author doesn't belong to group", 
 
   await runLottery(octokit, config, {
     repository: 'uesteibar/repository',
-    ref: `refs/pull/${prNumber}`
+    ref
   })
 
   getPullMock.done()
@@ -249,7 +249,7 @@ test("doesn't assign reviewers if the author doesn't belong to group", async () 
 
   await runLottery(octokit, config, {
     repository: 'uesteibar/repository',
-    ref: `refs/pull/${prNumber}`
+    ref
   })
 
   getPullMock.done()

--- a/src/lottery.ts
+++ b/src/lottery.ts
@@ -6,6 +6,7 @@ export interface Pull {
   user: {
     login: string
   }
+  number: number
   draft: boolean
 }
 interface Env {
@@ -17,7 +18,7 @@ class Lottery {
   octokit: Octokit
   config: Config
   env: Env
-  pr: Pull | null
+  pr: Pull | undefined
 
   constructor({
     octokit,
@@ -34,7 +35,7 @@ class Lottery {
       repository: env.repository,
       ref: env.ref
     }
-    this.pr = null
+    this.pr = undefined
   }
 
   async run(): Promise<void> {
@@ -136,26 +137,32 @@ class Lottery {
   }
 
   getPRNumber(): number {
-    return Number(this.env.ref.split('refs/pull/')[1].split('/')[0])
+    if (!this.pr) {
+      throw new Error('PR not set')
+    }
+    return Number(this.pr.number)
   }
 
-  async getPR(): Promise<Pull | null> {
+  async getPR(): Promise<Pull | undefined> {
     if (this.pr) return this.pr
 
     try {
-      const {data} = await this.octokit.pulls.get({
-        ...this.getOwnerAndRepo(),
-        pull_number: this.getPRNumber() // eslint-disable-line @typescript-eslint/camelcase
+      const {data} = await this.octokit.pulls.list({
+        ...this.getOwnerAndRepo()
       })
 
-      this.pr = data
+      this.pr = data.find(({head: {ref}}) => ref === this.env.ref)
+
+      if (!this.pr) {
+        throw new Error(`PR matching ref not found: ${this.env.ref}`)
+      }
 
       return this.pr
     } catch (error) {
       core.error(error)
       core.setFailed(error)
 
-      return null
+      return undefined
     }
   }
 }
@@ -165,7 +172,7 @@ export const runLottery = async (
   config: Config,
   env = {
     repository: process.env.GITHUB_REPOSITORY || '',
-    ref: process.env.GITHUB_REF || ''
+    ref: process.env.GITHUB_HEAD_REF || ''
   }
 ): Promise<void> => {
   const lottery = new Lottery({octokit, config, env})

--- a/src/lottery.ts
+++ b/src/lottery.ts
@@ -137,10 +137,7 @@ class Lottery {
   }
 
   getPRNumber(): number {
-    if (!this.pr) {
-      throw new Error('PR not set')
-    }
-    return Number(this.pr.number)
+    return Number(this.pr?.number)
   }
 
   async getPR(): Promise<Pull | undefined> {


### PR DESCRIPTION
By looking up the PR `GITHUB_HEAD_REF` instead of using the `GITHUB_REF` we allow this action to be run for `pull_request_target` GitHub action events.
https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target

I believe that for actions running on `pull_request`, `GITHUB_REF == GITHUB_HEAD_REF` so this should be backwards compatible.
https://docs.github.com/en/actions/reference/environment-variables


I'm conscious that I've made a couple of changes that are not aligned with some of the existing style, do let me know if you want me to revert them:
1. `this.pr` -> maybe `undefined` instead of `null`. This was for convenience with `.find` but also personally I try to avoid `null` in JS code because I don't want to have to deal with 2 different null states, so I choose the one js uses internally (ie. `undefined`)
2. Some shared state in the test code with `prNumber` and `basePull` - I don't see this as problematic but happy to change back to redefine inside every test case.


The reason this is useful for me in particular is that I wanted this to auto-run on PRs opened by dependabot, however [dependabot only has readonly access](https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/)


For completeness, this is what that action looks like:
```
name: Reviewer lottery
on: pull_request_target
jobs:
  test:
    if: github.event.pull_request.user.login == 'dependabot[bot]'
    runs-on: ubuntu-latest
    steps:
      - uses: actions/checkout@v2
      - uses: Phil-Barber/reviewer-lottery@pr_target
        with:
          repo-token: ${{ secrets.GITHUB_TOKEN }}
```