### PR TITLE
Add support for Github Enterprise users

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: uesteibar/reviewer-lottery@v3
+    - uses: omniplatypus/reviewer-lottery@v3.2.1
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+If you are a Github Enterprise user, you must provide a base url for your Github instance's API:
+
+```yaml
+name: "Reviewer lottery"
+on:
+  pull_request_target:
+    types: [opened, ready_for_review, reopened]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: omniplatypus/reviewer-lottery@v3.2.1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        base-url: https://git.yourcompany.com/api/v3
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: omniplatypus/reviewer-lottery@v3.2.1
+    - uses: uesteibar/reviewer-lottery@v3
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
 ```

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,9 +10,11 @@ async function run(): Promise<void> {
       throw new Error('missing GITHUB_REPOSITORY')
     //comes from {{secrets.GITHUB_TOKEN}}
     const token = core.getInput('repo-token', {required: true})
+    const userBaseUrl = core.getInput('base-url', {required: false})
     const config = getConfig()
+  
 
-    await runLottery(new Octokit({auth: token}), config)
+    await runLottery(new Octokit({auth: token, baseUrl: userBaseUrl}), config)
   } catch (error: any) {
     core.setFailed(error.message)
   }


### PR DESCRIPTION
When using Octokit with Github Enterprise, providing a base url is mandatory according to Github docs. This adds it as an optional parameter for these users.