### PR TITLE
Bugfix: ignore case when excluding author from reviewers list

### DIFF
--- a/src/lottery.ts
+++ b/src/lottery.ts
@@ -107,7 +107,8 @@ class Lottery {
   pickRandom(items: string[], n: number, ignore: string[]): string[] {
     const picks: string[] = []
 
-    const candidates = items.filter(item => !ignore.includes(item))
+    const ignoreLc = ignore.map(i => i.toLowerCase())
+    const candidates = items.filter(item => !ignoreLc.includes(item.toLowerCase()))
 
     while (picks.length < n) {
       const random = Math.floor(Math.random() * candidates.length)


### PR DESCRIPTION
If config file contains login in lowercase, but the login of a user is actually cased (like mine), action does not exclude author of PR from list of potential reviewers. This leads to errors like:
```
POST /repos/milaboratory/pl/pulls/1983/requested_reviewers - 422 with id 9008:31A545:8051653:1D43A1BA:6A3412DB in 304ms
  Error: HttpError: Review cannot be requested from pull request author. - https://docs.github.com/rest/pulls/review-requests#request-reviewers-for-a-pull-request
```